### PR TITLE
sprmrkt: hacking Monad with phantom type, Maybe, and -XOverloadedStrings

### DIFF
--- a/mengwong/sprmrkt/src/Lib.hs
+++ b/mengwong/sprmrkt/src/Lib.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE InstanceSigs #-}
 
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Lib where
 
-import Control.Monad (join)
+import Control.Monad (join, liftM, ap)
+import Data.String (IsString(..))
 
 someFunc :: IO ()
 someFunc = putStrLn "someFunc"
@@ -26,33 +28,74 @@ infixr 7 </>
 --   "mr"
 --   "kt"
 
+-- phantom type
+-- I did not use Maybe in first try. Worked perfectly with Monad but Applicative had funny behaviour.
+-- Added Maybe and fixed Applicative behaviour.
+newtype MyVowels a = MkV {unV :: Maybe [String]}
+  deriving (Show, Eq)
 
+-- overloaded strings
+instance IsString (MyVowels a) where
+  fromString string = MkV $ Just [string]
 
-newtype MyVowels a = MkV [a]
-  deriving (Show, Eq, Functor, Applicative)
-
--- ***Jacob: just use {-# LANGUAGE GeneralisedNewtypeDeriving #-} instead,
---           to derive Functor and Applicative
-
+-- basically, Functor and Applicative are derived from Monad
+instance Functor MyVowels where
+  fmap = liftM
+instance Applicative MyVowels where
+  (<*>) = ap
+  pure = return
 
 -- the "programmable semicolon" here inserts every possible vowel, in between lines of the "do"
 instance Monad MyVowels where
-  (>>=) :: (MyVowels a) -> (a -> MyVowels b) -> MyVowels b
-  (>>=) (MkV []) _ = MkV []
-  (>>=) (MkV xs) f =
-    -- let's start with a "simple" id
-    let -- ys :: [MyVowels b]
-        ys = [ f (x ++ [vowel])
-             | x <- xs
-             , vowel <- "aeiou" ]
-        unwrapped = concat [ zs
-                           | (MkV zs) <- ys
-                           ]
-        -- toreturn :: MyVowels c
-        toreturn = MkV unwrapped    -- sequence :: (Traversable t, Monad m) => t (m a) -> m (t a)
-    in
-      toreturn
+  (>>=) :: forall a b . MyVowels a -> (a -> MyVowels b) -> MyVowels b
+  (>>=) (MkV mxss) f =
+    let (MkV myss) = f undefined -- magic
+     in case (mxss,myss) of
+        (Just xss, Just yss) -> MkV $ Just $
+          [ xs ++ [vowel] ++ ys
+            | xs <- xss
+            , vowel <- "aeiou"
+            , ys <- yss
+          ]
+        (Just xss, Nothing) -> MkV $ Just xss
+        (Nothing, Just yss) -> MkV $ Just yss
+        _ -> MkV Nothing
+        
+  return _ = MkV Nothing
 
--- this works with
--- let monadicUC str = MkV [stringUpper str]
+example :: MyVowels () = "x"
+-- >>> example
+-- MkV {unV = Just ["x"]}
 
+example1 :: MyVowels () = do
+  "x"
+  "y"
+example2 :: MyVowels () = do
+  "x"
+  "y"
+  "z"
+
+-- >>> example1
+-- >>> fmap length $ unV example1
+-- >>> example2
+-- >>> fmap length $ unV example2
+-- MkV {unV = Just ["xay","xey","xiy","xoy","xuy"]}
+-- Just 5
+-- MkV {unV = Just ["xayaz","xayez","xayiz","xayoz","xayuz","xeyaz","xeyez","xeyiz","xeyoz","xeyuz","xiyaz","xiyez","xiyiz","xiyoz","xiyuz","xoyaz","xoyez","xoyiz","xoyoz","xoyuz","xuyaz","xuyez","xuyiz","xuyoz","xuyuz"]}
+-- Just 25
+
+-- >>> "x" :: MyVowels ()
+-- >>> "x" <*> "y" :: MyVowels ()
+-- >>> "x" <*> "y" <*> "z" :: MyVowels ()
+-- MkV {unV = Just ["x"]}
+-- MkV {unV = Just ["xay","xey","xiy","xoy","xuy"]}
+-- MkV {unV = Just ["xayaz","xayez","xayiz","xayoz","xayuz","xeyaz","xeyez","xeyiz","xeyoz","xeyuz","xiyaz","xiyez","xiyiz","xiyoz","xiyuz","xoyaz","xoyez","xoyiz","xoyoz","xoyuz","xuyaz","xuyez","xuyiz","xuyoz","xuyuz"]}
+
+-- >>> sequence [] :: MyVowels [()]
+-- >>> sequence ["x" :: MyVowels ()]
+-- >>> sequence ["x" :: MyVowels (), "y"]
+-- >>> sequence ["x" :: MyVowels (), "y", "z"]
+-- MkV {unV = Nothing}
+-- MkV {unV = Just ["x"]}
+-- MkV {unV = Just ["xay","xey","xiy","xoy","xuy"]}
+-- MkV {unV = Just ["xayaz","xayez","xayiz","xayoz","xayuz","xeyaz","xeyez","xeyiz","xeyoz","xeyuz","xiyaz","xiyez","xiyiz","xiyoz","xiyuz","xoyaz","xoyez","xoyiz","xoyoz","xoyuz","xuyaz","xuyez","xuyiz","xuyoz","xuyuz"]}


### PR DESCRIPTION
It is done :D

I saved a copy in my account.
https://github.com/2jacobtan/Haskell-Practice/blob/master/VowelBetweenConsonants.hs

┌─[20210225-00:52:59] ‡ [jt2@JACOBTAN039FL:~/repos/smucclaw/sandbox/mengwong/sprmrkt]
└─[0] <git:(meng-sprmrkt-jacob 2016043✱) > ghci src/Lib.hs -XOverloadedStringsGHCi, version 8.8.4: https://www.haskell.org/ghc/  :? for help
Loaded package environment from /home/jt2/.ghc/x86_64-linux-8.8.4/environments/default
Loaded GHCi configuration from /home/jt2/.ghc/ghci.conf
[1 of 1] Compiling Lib              ( src/Lib.hs, interpreted )
Ok, one module loaded.
*Lib PPrint> do {"x"; "y"} :: MyVowels ()
MkV
    { unV = Just
        [ "xay"
        , "xey"
        , "xiy"
        , "xoy"
        , "xuy"
        ]
    }
*Lib PPrint> do {"x"} :: MyVowels ()
MkV
    { unV = Just [ "x" ] }
*Lib PPrint> do {"x","y","z"} :: MyVowels ()

<interactive>:3:8: error: parse error on input ‘,’
*Lib PPrint> do {"x";"y";"z"} :: MyVowels ()
MkV
    { unV = Just
        [ "xayaz"
        , "xayez"
        , "xayiz"
        , "xayoz"
        , "xayuz"
        , "xeyaz"
        , "xeyez"
        , "xeyiz"
        , "xeyoz"
        , "xeyuz"
        , "xiyaz"
        , "xiyez"
        , "xiyiz"
        , "xiyoz"
        , "xiyuz"
        , "xoyaz"
        , "xoyez"
        , "xoyiz"
        , "xoyoz"
        , "xoyuz"
        , "xuyaz"
        , "xuyez"
        , "xuyiz"
        , "xuyoz"
        , "xuyuz"
        ]
    }
*Lib PPrint> 